### PR TITLE
feat(auth): add per-profile read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based loosely on Keep a Changelog, and versions are recorded using
 
 ## Unreleased
 
+### Added
+
+- Per-profile read-only mode. Use `mm auth login --readonly` to create a read-only profile, or `mm auth set-readonly <profile> on|off` to toggle. When enabled, mm refuses any HTTP request that would mutate state on the Mattermost server (only GET/HEAD/OPTIONS and POST to `/search` endpoints are allowed).
+- `mm auth list` and `mm auth status` now show the read-only flag.
+
 ## [0.2.0] - 2026-03-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A full-featured command-line client for [Mattermost](https://mattermost.com).
 
 ## Features
 
-- **Multi-server profiles** with token and password authentication
+- **Multi-server profiles** with token and password authentication, including a per-profile read-only mode that blocks all mutations
 - **Real-time notifications** via WebSocket with event and channel filtering
 - **Full post lifecycle**: create, edit, delete, pin, react, search, threads, reminders
 - **Channel management**: join, leave, create, archive, read, favorite, notify settings
@@ -100,10 +100,12 @@ mm notify --json                   # JSON output for scripting
 ```bash
 mm auth login --url URL --token TOKEN   # login with token
 mm auth login --url URL -u USER -p PASS # login with password
+mm auth login --url URL ... --readonly  # mark new profile as read-only
 mm auth status                          # show current profile
 mm auth list                            # list all profiles
 mm auth switch <profile>                # switch active profile
 mm auth remove <profile>                # remove a profile
+mm auth set-readonly <profile> on|off   # toggle read-only mode on a profile
 mm auth sessions                        # list active sessions
 mm auth revoke-session <session-id>     # revoke a session
 mm auth revoke-all                      # revoke all sessions

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -24,6 +25,16 @@ func New() (*model.Client4, *config.ServerProfile, error) {
 	serverURL = strings.TrimRight(serverURL, "/")
 	apiClient := model.NewAPIv4Client(serverURL)
 	apiClient.SetToken(server.Token)
+	if server.Readonly {
+		base := apiClient.HTTPClient.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		apiClient.HTTPClient.Transport = &readonlyTransport{
+			profile: server.Name,
+			base:    base,
+		}
+	}
 	return apiClient, server, nil
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,7 +2,55 @@ package client
 
 import (
 	"testing"
+
+	"github.com/ziyan/mm/internal/config"
 )
+
+func TestNewInstallsReadonlyTransport(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", directory)
+
+	configuration := &config.Config{Profiles: map[string]config.ServerProfile{}}
+	configuration.SetProfile("ro", config.ServerProfile{
+		URL:      "https://mm.example.com",
+		Token:    "tok",
+		Readonly: true,
+	})
+	configuration.SetProfile("rw", config.ServerProfile{
+		URL:   "https://mm.example.com",
+		Token: "tok",
+	})
+
+	configuration.ActiveProfile = "ro"
+	if err := configuration.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	apiClient, server, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if !server.Readonly {
+		t.Fatalf("server.Readonly = false, want true")
+	}
+	if _, ok := apiClient.HTTPClient.Transport.(*readonlyTransport); !ok {
+		t.Fatalf("HTTPClient.Transport = %T, want *readonlyTransport", apiClient.HTTPClient.Transport)
+	}
+
+	configuration.ActiveProfile = "rw"
+	if err := configuration.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	apiClient, server, err = New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if server.Readonly {
+		t.Fatalf("server.Readonly = true, want false")
+	}
+	if _, ok := apiClient.HTTPClient.Transport.(*readonlyTransport); ok {
+		t.Fatalf("HTTPClient.Transport should not be *readonlyTransport for writable profile")
+	}
+}
 
 func TestWebSocketUrl(t *testing.T) {
 	tests := []struct {

--- a/internal/client/readonly.go
+++ b/internal/client/readonly.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ReadonlyError is returned by the readonly transport when a mutating request
+// is attempted against a profile marked as readonly.
+type ReadonlyError struct {
+	Profile string
+	Method  string
+	Path    string
+}
+
+func (self *ReadonlyError) Error() string {
+	return fmt.Sprintf("readonly profile %q: refusing to %s %s", self.Profile, self.Method, self.Path)
+}
+
+// readonlyTransport blocks any HTTP request that would mutate server state.
+//
+// GET, HEAD, and OPTIONS are always allowed. POST is allowed only when the
+// path ends with "/search", which covers Mattermost's search endpoints
+// (users, posts, channels, files, emoji, etc.) — those use POST to carry a
+// JSON body but do not mutate state.
+type readonlyTransport struct {
+	profile string
+	base    http.RoundTripper
+}
+
+func (self *readonlyTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if !isReadonlySafe(request.Method, request.URL.Path) {
+		return nil, &ReadonlyError{
+			Profile: self.profile,
+			Method:  request.Method,
+			Path:    request.URL.Path,
+		}
+	}
+	return self.base.RoundTrip(request)
+}
+
+func isReadonlySafe(method, path string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	case http.MethodPost:
+		return strings.HasSuffix(path, "/search")
+	}
+	return false
+}

--- a/internal/client/readonly_test.go
+++ b/internal/client/readonly_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type recordingTransport struct {
+	calls int
+}
+
+func (self *recordingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	self.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    request,
+	}, nil
+}
+
+func TestIsReadonlySafe(t *testing.T) {
+	tests := []struct {
+		method string
+		path   string
+		want   bool
+	}{
+		{"GET", "/api/v4/users/me", true},
+		{"HEAD", "/api/v4/users/me", true},
+		{"OPTIONS", "/api/v4/users/me", true},
+		{"get", "/api/v4/users/me", true},
+		{"POST", "/api/v4/users/search", true},
+		{"POST", "/api/v4/teams/abc/posts/search", true},
+		{"POST", "/api/v4/channels/search", true},
+		{"POST", "/api/v4/teams/abc/files/search", true},
+		{"POST", "/api/v4/posts", false},
+		{"POST", "/api/v4/channels", false},
+		{"PUT", "/api/v4/users/me/patch", false},
+		{"PATCH", "/api/v4/posts/123/patch", false},
+		{"DELETE", "/api/v4/posts/123", false},
+	}
+	for _, tt := range tests {
+		got := isReadonlySafe(tt.method, tt.path)
+		if got != tt.want {
+			t.Errorf("isReadonlySafe(%q, %q) = %v, want %v", tt.method, tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestReadonlyTransportAllowsReads(t *testing.T) {
+	base := &recordingTransport{}
+	transport := &readonlyTransport{profile: "p", base: base}
+
+	allowed := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/api/v4/users/me"},
+		{"HEAD", "/api/v4/posts/123"},
+		{"OPTIONS", "/api/v4/teams"},
+		{"POST", "/api/v4/users/search"},
+	}
+
+	for _, tt := range allowed {
+		request := httptest.NewRequest(tt.method, "https://mm.example.com"+tt.path, nil)
+		response, err := transport.RoundTrip(request)
+		if err != nil {
+			t.Errorf("RoundTrip(%s %s) error: %v", tt.method, tt.path, err)
+			continue
+		}
+		_ = response.Body.Close()
+	}
+
+	if base.calls != len(allowed) {
+		t.Errorf("base RoundTripper called %d times, want %d", base.calls, len(allowed))
+	}
+}
+
+func TestReadonlyTransportBlocksMutations(t *testing.T) {
+	base := &recordingTransport{}
+	transport := &readonlyTransport{profile: "myprofile", base: base}
+
+	blocked := []struct {
+		method string
+		path   string
+	}{
+		{"POST", "/api/v4/posts"},
+		{"POST", "/api/v4/channels"},
+		{"PUT", "/api/v4/users/me/patch"},
+		{"PATCH", "/api/v4/posts/123/patch"},
+		{"DELETE", "/api/v4/posts/123"},
+	}
+
+	for _, tt := range blocked {
+		request := httptest.NewRequest(tt.method, "https://mm.example.com"+tt.path, nil)
+		response, err := transport.RoundTrip(request)
+		if err == nil {
+			t.Errorf("RoundTrip(%s %s) expected error, got nil", tt.method, tt.path)
+			if response != nil {
+				_ = response.Body.Close()
+			}
+			continue
+		}
+		var readonlyError *ReadonlyError
+		if !errors.As(err, &readonlyError) {
+			t.Errorf("RoundTrip(%s %s) error type = %T, want *ReadonlyError", tt.method, tt.path, err)
+			continue
+		}
+		if readonlyError.Profile != "myprofile" {
+			t.Errorf("ReadonlyError.Profile = %q, want %q", readonlyError.Profile, "myprofile")
+		}
+		if readonlyError.Method != tt.method {
+			t.Errorf("ReadonlyError.Method = %q, want %q", readonlyError.Method, tt.method)
+		}
+		if readonlyError.Path != tt.path {
+			t.Errorf("ReadonlyError.Path = %q, want %q", readonlyError.Path, tt.path)
+		}
+	}
+
+	if base.calls != 0 {
+		t.Errorf("base RoundTripper called %d times, want 0", base.calls)
+	}
+}
+
+func TestReadonlyErrorMessage(t *testing.T) {
+	err := &ReadonlyError{Profile: "prod", Method: "POST", Path: "/api/v4/posts"}
+	want := `readonly profile "prod": refusing to POST /api/v4/posts`
+	if err.Error() != want {
+		t.Errorf("Error() = %q, want %q", err.Error(), want)
+	}
+}

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -27,6 +27,7 @@ func init() {
 	loginCommand.Flags().StringP("token", "t", "", "Personal access token")
 	loginCommand.Flags().StringP("user", "u", "", "Username or email (for password login)")
 	loginCommand.Flags().StringP("password", "p", "", "Password (for password login)")
+	loginCommand.Flags().Bool("readonly", false, "Mark profile as read-only (block all mutating requests)")
 	_ = loginCommand.MarkFlagRequired("url")
 
 	statusCommand := &cobra.Command{
@@ -55,7 +56,16 @@ func init() {
 		RunE:  authRemoveRun,
 	}
 
-	authCommand.AddCommand(loginCommand, statusCommand, listCommand, switchCommand, removeCommand)
+	setReadonlyCommand := &cobra.Command{
+		Use:   "set-readonly <profile> <on|off>",
+		Short: "Toggle the read-only flag on a profile",
+		Long: "Toggle the read-only flag on a profile. When read-only is on, mm refuses any " +
+			"request that would mutate state on the Mattermost server for that profile.",
+		Args: cobra.ExactArgs(2),
+		RunE: authSetReadonlyRun,
+	}
+
+	authCommand.AddCommand(loginCommand, statusCommand, listCommand, switchCommand, removeCommand, setReadonlyCommand)
 	rootCommand.AddCommand(authCommand)
 }
 
@@ -65,6 +75,7 @@ func authLoginRun(command *cobra.Command, args []string) error {
 	token, _ := command.Flags().GetString("token")
 	username, _ := command.Flags().GetString("user")
 	password, _ := command.Flags().GetString("password")
+	readonly, _ := command.Flags().GetBool("readonly")
 
 	serverURL = strings.TrimRight(serverURL, "/")
 	if !strings.HasPrefix(serverURL, "http") {
@@ -109,6 +120,7 @@ func authLoginRun(command *cobra.Command, args []string) error {
 		URL:      serverURL,
 		Token:    token,
 		Username: currentUser.Username,
+		Readonly: readonly,
 	})
 	configuration.ActiveProfile = profileName
 
@@ -116,7 +128,11 @@ func authLoginRun(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	printer.PrintSuccess("Logged in to %s as %s (profile: %s)", serverURL, currentUser.Username, profileName)
+	mode := ""
+	if readonly {
+		mode = " [readonly]"
+	}
+	printer.PrintSuccess("Logged in to %s as %s (profile: %s)%s", serverURL, currentUser.Username, profileName, mode)
 	return nil
 }
 
@@ -141,7 +157,15 @@ func authStatusRun(command *cobra.Command, args []string) error {
 	if server.TeamName != "" {
 		printer.PrintInfo("Team:     %s", server.TeamName)
 	}
+	printer.PrintInfo("Readonly: %s", boolText(server.Readonly))
 	return nil
+}
+
+func boolText(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
 }
 
 func authListRun(command *cobra.Command, args []string) error {
@@ -166,9 +190,13 @@ func authListRun(command *cobra.Command, args []string) error {
 		if profile.Name == configuration.ActiveProfile {
 			active = "*"
 		}
-		rows = append(rows, []string{active, profile.Name, profile.URL, profile.Username})
+		readonly := ""
+		if profile.Readonly {
+			readonly = "yes"
+		}
+		rows = append(rows, []string{active, profile.Name, profile.URL, profile.Username, readonly})
 	}
-	printer.PrintTable([]string{"", "NAME", "URL", "USER"}, rows)
+	printer.PrintTable([]string{"", "NAME", "URL", "USER", "READONLY"}, rows)
 	return nil
 }
 
@@ -211,4 +239,43 @@ func authRemoveRun(command *cobra.Command, args []string) error {
 	}
 	printer.PrintSuccess("Removed profile %s", profileName)
 	return nil
+}
+
+func authSetReadonlyRun(command *cobra.Command, args []string) error {
+	profileName := args[0]
+	value, err := parseOnOff(args[1])
+	if err != nil {
+		return err
+	}
+
+	configuration, err := config.Load()
+	if err != nil {
+		return err
+	}
+	profile, ok := configuration.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	profile.Readonly = value
+	configuration.Profiles[profileName] = profile
+	if err := configuration.Save(); err != nil {
+		return err
+	}
+
+	if value {
+		printer.PrintSuccess("Profile %s is now read-only", profileName)
+	} else {
+		printer.PrintSuccess("Profile %s is now writable", profileName)
+	}
+	return nil
+}
+
+func parseOnOff(input string) (bool, error) {
+	switch strings.ToLower(input) {
+	case "on", "true", "yes", "1", "enable", "enabled":
+		return true, nil
+	case "off", "false", "no", "0", "disable", "disabled":
+		return false, nil
+	}
+	return false, fmt.Errorf("invalid value %q: expected on or off", input)
 }

--- a/internal/commands/auth_test.go
+++ b/internal/commands/auth_test.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/ziyan/mm/internal/config"
+)
+
+func TestParseOnOff(t *testing.T) {
+	truthy := []string{"on", "ON", "true", "True", "yes", "1", "enable", "enabled"}
+	falsy := []string{"off", "OFF", "false", "no", "0", "disable", "disabled"}
+	invalid := []string{"", "maybe", "2", "yess"}
+
+	for _, value := range truthy {
+		got, err := parseOnOff(value)
+		if err != nil {
+			t.Errorf("parseOnOff(%q) error: %v", value, err)
+			continue
+		}
+		if !got {
+			t.Errorf("parseOnOff(%q) = false, want true", value)
+		}
+	}
+
+	for _, value := range falsy {
+		got, err := parseOnOff(value)
+		if err != nil {
+			t.Errorf("parseOnOff(%q) error: %v", value, err)
+			continue
+		}
+		if got {
+			t.Errorf("parseOnOff(%q) = true, want false", value)
+		}
+	}
+
+	for _, value := range invalid {
+		if _, err := parseOnOff(value); err == nil {
+			t.Errorf("parseOnOff(%q) expected error", value)
+		}
+	}
+}
+
+func TestAuthSetReadonlyTogglesProfile(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", directory)
+
+	configuration := &config.Config{Profiles: map[string]config.ServerProfile{}}
+	configuration.SetProfile("test", config.ServerProfile{
+		URL:   "https://mm.example.com",
+		Token: "tok",
+	})
+	if err := configuration.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := runCommand("auth", "set-readonly", "test", "on"); err != nil {
+		t.Fatalf("set-readonly on: %v", err)
+	}
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !loaded.Profiles["test"].Readonly {
+		t.Fatalf("expected Readonly=true after set-readonly on")
+	}
+
+	if _, err := runCommand("auth", "set-readonly", "test", "off"); err != nil {
+		t.Fatalf("set-readonly off: %v", err)
+	}
+	loaded, err = config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Profiles["test"].Readonly {
+		t.Fatalf("expected Readonly=false after set-readonly off")
+	}
+
+	if _, err := runCommand("auth", "set-readonly", "missing", "on"); err == nil {
+		t.Fatalf("expected error for missing profile")
+	}
+
+	if _, err := runCommand("auth", "set-readonly", "test", "maybe"); err == nil {
+		t.Fatalf("expected error for invalid value")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type ServerProfile struct {
 	Username string `json:"username,omitempty"`
 	TeamID   string `json:"team_id,omitempty"`
 	TeamName string `json:"team_name,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
 }
 
 type Config struct {


### PR DESCRIPTION
## Summary

- Adds a `Readonly` flag to each auth profile, persisted in `config.json`.
- `mm auth login --readonly` creates a read-only profile; `mm auth set-readonly <profile> on|off` toggles it on existing profiles.
- When the active profile is read-only, the Mattermost HTTP client is wrapped with a transport that allows only GET/HEAD/OPTIONS and POST to `/search` endpoints (Mattermost's search APIs use POST but are read-only). Any other request fails fast with a typed `ReadonlyError` before reaching the wire — no need to mark individual commands.
- `mm auth status` and `mm auth list` now show the read-only flag.

## Test plan

- [x] `go test ./...` (unit tests for transport allow/block matrix, error message, `client.New` wiring, `parseOnOff`, and end-to-end toggle via the in-process command runner)
- [x] `gofmt`, `goimports`, `go vet`, `golangci-lint run ./...`
- [x] `mm auth login --help` and `mm auth set-readonly --help` smoke-tested locally
- [ ] Manual: log in with `--readonly`, confirm `mm post create ...` returns the readonly error and `mm post list ...` still works


## Changelog

### Added

- Per-profile read-only mode. Use `mm auth login --readonly` to create a read-only profile, or `mm auth set-readonly <profile> on|off` to toggle. When enabled, mm refuses any HTTP request that would mutate state on the Mattermost server (only GET/HEAD/OPTIONS and POST to `/search` endpoints are allowed).
- `mm auth list` and `mm auth status` now show the read-only flag.
