### PR TITLE
Fix channel resolution to support ID, slug, and display name

### DIFF
--- a/internal/commands/channel.go
+++ b/internal/commands/channel.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/spf13/cobra"
@@ -90,12 +91,45 @@ func resolveChannelId(ctx context.Context, apiClient *model.Client4, teamId, cha
 		}
 	}
 
-	// Try as channel name
+	// Try as channel slug (Name field)
 	channel, _, err := apiClient.GetChannelByName(ctx, channelNameOrId, teamId, "")
-	if err != nil {
-		return "", fmt.Errorf("channel %q not found: %w", channelNameOrId, err)
+	if err == nil {
+		return channel.Id, nil
 	}
-	return channel.Id, nil
+
+	// Try as display name via search
+	return resolveChannelIdByDisplayName(ctx, apiClient, teamId, channelNameOrId)
+}
+
+func resolveChannelIdByDisplayName(ctx context.Context, apiClient *model.Client4, teamId, displayName string) (string, error) {
+	// Enumerate the user's accessible channels and match by display name.
+	// This avoids depending on Mattermost search tokenization, which fails
+	// for display names containing punctuation or hyphens.
+	currentUser, _, err := apiClient.GetMe(ctx, "")
+	if err != nil {
+		return "", fmt.Errorf("channel %q not found: %w", displayName, err)
+	}
+
+	channels, _, err := apiClient.GetChannelsForTeamForUser(ctx, teamId, currentUser.Id, false, "")
+	if err != nil {
+		return "", fmt.Errorf("channel %q not found: %w", displayName, err)
+	}
+
+	normalized := normalizeDisplayName(displayName)
+	for _, channel := range channels {
+		if strings.EqualFold(channel.DisplayName, displayName) {
+			return channel.Id, nil
+		}
+		if normalizeDisplayName(channel.DisplayName) == normalized {
+			return channel.Id, nil
+		}
+	}
+	return "", fmt.Errorf("channel %q not found", displayName)
+}
+
+// normalizeDisplayName collapses whitespace and lowercases for fuzzy matching.
+func normalizeDisplayName(name string) string {
+	return strings.Join(strings.Fields(strings.ToLower(name)), " ")
 }
 
 func channelListRun(command *cobra.Command, args []string) error {
@@ -262,7 +296,12 @@ func channelInfoRun(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	channel, _, err := apiClient.GetChannelByName(ctx, args[0], teamId, "")
+	channelId, err := resolveChannelId(ctx, apiClient, teamId, args[0])
+	if err != nil {
+		return err
+	}
+
+	channel, _, err := apiClient.GetChannel(ctx, channelId)
 	if err != nil {
 		return fmt.Errorf("channel not found: %w", err)
 	}

--- a/internal/commands/channel_test.go
+++ b/internal/commands/channel_test.go
@@ -70,3 +70,102 @@ func TestIntegrationChannelMembers(t *testing.T) {
 		t.Errorf("expected admin in channel members, got: %s", output)
 	}
 }
+
+func TestNormalizeDisplayName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Mujin Team - Quicktron AGVs", "mujin team - quicktron agvs"},
+		{"Town Square", "town square"},
+		{"  extra   spaces  ", "extra spaces"},
+		{"ALLCAPS", "allcaps"},
+		{"single", "single"},
+		{"hello\tworld", "hello world"},
+	}
+	for _, test := range tests {
+		result := normalizeDisplayName(test.input)
+		if result != test.expected {
+			t.Errorf("normalizeDisplayName(%q) = %q, want %q", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestIntegrationChannelResolveByDisplayName(t *testing.T) {
+	skipIntegration(t)
+
+	// Create a channel with a multi-word display name
+	channelName := fmt.Sprintf("int-dispname-%d", time.Now().UnixNano())
+	displayName := "Integration Display Name Test Channel"
+	output, err := runCommand("channel", "create", channelName, "--display-name", displayName)
+	if err != nil {
+		t.Fatalf("channel create failed: %v\n%s", err, output)
+	}
+
+	// Resolve by slug (existing behavior)
+	output, err = runCommand("channel", "info", channelName)
+	if err != nil {
+		t.Fatalf("channel info by slug failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, displayName) {
+		t.Errorf("expected display name in output, got: %s", output)
+	}
+
+	// Resolve by display name (new behavior)
+	output, err = runCommand("channel", "info", displayName)
+	if err != nil {
+		t.Fatalf("channel info by display name failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, channelName) {
+		t.Errorf("expected slug in output when resolved by display name, got: %s", output)
+	}
+
+	// Resolve by display name with different casing
+	output, err = runCommand("channel", "info", strings.ToLower(displayName))
+	if err != nil {
+		t.Fatalf("channel info by lowercase display name failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, channelName) {
+		t.Errorf("expected slug in output when resolved by lowercase display name, got: %s", output)
+	}
+
+	// Resolve default channel "Town Square" by display name
+	output, err = runCommand("channel", "info", "Town Square")
+	if err != nil {
+		t.Fatalf("channel info by display name 'Town Square' failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "town-square") {
+		t.Errorf("expected 'town-square' in output, got: %s", output)
+	}
+}
+
+func TestIntegrationChannelResolveByDisplayNameWithPunctuation(t *testing.T) {
+	skipIntegration(t)
+
+	// Create a channel with hyphens, spaces, and mixed case in the display name,
+	// mimicking names like "Mujin Team - Quicktron AGVs" that fail search tokenization.
+	channelName := fmt.Sprintf("int-punct-%d", time.Now().UnixNano())
+	displayName := "Int Team - Quicktron AGVs"
+	output, err := runCommand("channel", "create", channelName, "--display-name", displayName)
+	if err != nil {
+		t.Fatalf("channel create failed: %v\n%s", err, output)
+	}
+
+	// Resolve by exact display name
+	output, err = runCommand("channel", "info", displayName)
+	if err != nil {
+		t.Fatalf("channel info by punctuated display name failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, channelName) {
+		t.Errorf("expected slug %q in output, got: %s", channelName, output)
+	}
+
+	// Resolve by display name with different casing
+	output, err = runCommand("channel", "info", strings.ToLower(displayName))
+	if err != nil {
+		t.Fatalf("channel info by lowercase punctuated display name failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, channelName) {
+		t.Errorf("expected slug %q in output, got: %s", channelName, output)
+	}
+}


### PR DESCRIPTION
## Summary
- `resolveChannelId` now falls back to display-name matching when ID and slug lookups fail, by enumerating the user's accessible channels and comparing with case-insensitive/normalized matching.
- This fixes resolution for channels with punctuation, hyphens, or spaces in display names (e.g. "Mujin Team - Quicktron AGVs") that Mattermost search tokenization cannot handle.
- `channelInfoRun` now uses the shared `resolveChannelId` resolver instead of calling `GetChannelByName` directly, ensuring all channel subcommands resolve channels consistently.

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `go vet ./...` — no issues
- [x] `go build ./...` — builds cleanly
- [x] `TestNormalizeDisplayName` unit test passes (whitespace collapsing, lowercasing)
- [ ] Integration tests (`TestIntegrationChannelResolveByDisplayName`, `TestIntegrationChannelResolveByDisplayNameWithPunctuation`) verify end-to-end resolution against a live Mattermost instance


## Changelog

### Changed

- `channel info` and other channel-arg commands now resolve channels by display name (in addition to the 26-char ID and slug), including names with hyphens or spaces that Mattermost search tokenization can't handle.
